### PR TITLE
fetch updated RDS CA certificate bundle

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("com.twilio" % "sbt-guardrail" % "0.52.1")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.11.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [8688dguvj](https://app.clickup.com/t/8688dguvj)

Upgrading the CA we pull down to trust when connecting to our PostgreSQL database using `ssl_mode=verify-ca`. The old CA is set to expire in August 2024 so we will need to upgrade our RDS CA. This change allows us to do that without introducing downtime.

## Testing
Built and ran the images locally to ensure the new CA cert bundle was put in the right location.

Tested using the bundle separately:
- locally (from the dev jump box) using the bundled PEM in place of the single expiring certificate.
- with a JDBC connection via the pennsieve-api repo in: https://github.com/Pennsieve/pennsieve-api/pull/287